### PR TITLE
Add some guards againts race conditions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,12 @@ steps:
     commands:
       - go get gonum.org/v1/gonum/graph
       - cd dfd && go vet
+  - name: race
+    image: golang:1.11-stretch
+    pull: always
+    commands:
+      - go get gonum.org/v1/gonum/graph
+      - cd dfd && go test -race
   - name: test
     image: golang:1.11-stretch
     pull: always

--- a/dfd/dfd_test.go
+++ b/dfd/dfd_test.go
@@ -169,3 +169,25 @@ func TestTrustBoundaryAddNodeElem(t *testing.T) {
 		})
 	}
 }
+
+func TestDFDAddRemoveFlowRace(t *testing.T) {
+	g := InitializeDFD("test")
+	for i := 0; i < 5; i++ {
+		go func() {
+			p1 := NewProcess("p1")
+			p2 := NewProcess("p2")
+			g.AddFlow(p1, p2, "foo")
+			g.RemoveFlow(p1.DOTID(), p2.DOTID())
+		}()
+	}
+}
+
+func TestDFDAddNodeRace(t *testing.T) {
+	g := InitializeDFD("test")
+	for i := 0; i < 5; i++ {
+		go func() {
+			p1 := NewProcess("p1")
+			g.AddNodeElem(p1)
+		}()
+	}
+}


### PR DESCRIPTION
Maps in Go are not thread safe, and many libraries (such as Terraform)
that use this package are going to execute things concurrently. I don't
know that I've stomped out every race condition, but I'm confident I've
taken care of the most common occurrences.

Related to https://github.com/marqeta/terraform-provider-dfd/issues/2