### PR TITLE
Refactor graph code to eliminate race conditions

### DIFF
--- a/dfd/attributes.go
+++ b/dfd/attributes.go
@@ -1,0 +1,19 @@
+package dfd
+
+import (
+	"gonum.org/v1/gonum/graph/encoding"
+)
+
+type attributes []encoding.Attribute
+
+func (a attributes) Attributes() []encoding.Attribute {
+	return []encoding.Attribute(a)
+}
+func (a *attributes) SetAttribute(attr encoding.Attribute) error {
+	*a = append(*a, attr)
+	return nil
+}
+
+type dotPortLabels struct {
+	Port, Compass string
+}

--- a/dfd/client.go
+++ b/dfd/client.go
@@ -90,8 +90,5 @@ func (client *Client) DFDToDOT(dfd encoding.Builder) (string, error) {
 
 // Wrapper function for Marshal method in the dot package
 func (client *Client) marshal(dfd encoding.Builder) ([]byte, error) {
-	// FIXME: This is a temporary fix. The underlying methods in the graph should be made threadsafe
-	dfd.(*DataFlowDiagram).mtx.Lock()
-	defer dfd.(*DataFlowDiagram).mtx.Unlock()
 	return dot.Marshal(dfd, "", "", "\t")
 }

--- a/dfd/directed.go
+++ b/dfd/directed.go
@@ -1,0 +1,185 @@
+package dfd
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+// AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
+func (g *dfdGraph) AddNode(n graph.Node) {
+	if _, exists := g.nodes[n.ID()]; exists {
+		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
+	}
+	g.nodes[n.ID()] = n
+	g.from[n.ID()] = make(map[int64]graph.Edge)
+	g.to[n.ID()] = make(map[int64]graph.Edge)
+	g.nodeIDs.Use(n.ID())
+}
+
+// Edge returns the edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *dfdGraph) Edge(uid, vid int64) graph.Edge {
+	g.mtx.RLock()
+	defer g.mtx.RUnlock()
+	edge, ok := g.from[uid][vid]
+	if !ok {
+		return nil
+	}
+	return edge
+}
+
+// Edges returns all the edges in the graph.
+func (g *dfdGraph) Edges() graph.Edges {
+	var edges []graph.Edge
+	for _, u := range g.nodes {
+		for _, e := range g.from[u.ID()] {
+			edges = append(edges, e)
+		}
+	}
+	return iterator.NewOrderedEdges(edges)
+}
+
+// From returns all nodes in g that can be reached directly from n.
+func (g *dfdGraph) From(id int64) graph.Nodes {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	if _, ok := g.from[id]; !ok {
+		return nil
+	}
+
+	from := make([]graph.Node, len(g.from[id]))
+	i := 0
+	for vid := range g.from[id] {
+		from[i] = g.nodes[vid]
+		i++
+	}
+	return iterator.NewOrderedNodes(from)
+}
+
+// HasEdgeBetween returns whether an edge exists between nodes x and y without
+// considering direction.
+func (g *dfdGraph) HasEdgeBetween(xid, yid int64) bool {
+	if _, ok := g.from[xid][yid]; ok {
+		return true
+	}
+	_, ok := g.from[yid][xid]
+	return ok
+}
+
+// HasEdgeFromTo returns whether an edge exists in the graph from u to v.
+func (g *dfdGraph) HasEdgeFromTo(uid, vid int64) bool {
+	if _, ok := g.from[uid][vid]; !ok {
+		return false
+	}
+	return true
+}
+
+// NewEdge returns a new Edge from the source to the destination node.
+func (g *dfdGraph) NewEdge(from, to graph.Node) graph.Edge {
+	return &simple.Edge{F: from, T: to}
+}
+
+// Node returns the node with the given ID if it exists in the graph,
+// and nil otherwise.
+func (g *dfdGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
+}
+
+// Nodes returns all the nodes in the graph.
+func (g *dfdGraph) Nodes() graph.Nodes {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	if len(g.nodes) == 0 {
+		return nil
+	}
+	nodes := make([]graph.Node, len(g.nodes))
+	i := 0
+	for _, n := range g.nodes {
+		nodes[i] = n
+		i++
+	}
+	return iterator.NewOrderedNodes(nodes)
+}
+
+// RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
+// nodes. If the edge does not exist it is a no-op.
+func (g *dfdGraph) RemoveEdge(fid, tid int64) {
+	if _, ok := g.nodes[fid]; !ok {
+		return
+	}
+	if _, ok := g.nodes[tid]; !ok {
+		return
+	}
+
+	delete(g.from[fid], tid)
+	delete(g.to[tid], fid)
+}
+
+// RemoveNode removes the node with the given ID from the graph, as well as any edges attached
+// to it. If the node is not in the graph it is a no-op.
+func (g *dfdGraph) RemoveNode(id int64) {
+	if _, ok := g.nodes[id]; !ok {
+		return
+	}
+	delete(g.nodes, id)
+
+	for from := range g.from[id] {
+		delete(g.to[from], id)
+	}
+	delete(g.from, id)
+
+	for to := range g.to[id] {
+		delete(g.from[to], id)
+	}
+	delete(g.to, id)
+
+	g.nodeIDs.Release(id)
+}
+
+// SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the edge otherwise.
+// It will panic if the IDs of the e.From and e.To are equal.
+func (g *dfdGraph) SetEdge(e graph.Edge) {
+	var (
+		from = e.From()
+		fid  = from.ID()
+		to   = e.To()
+		tid  = to.ID()
+	)
+
+	if fid == tid {
+		panic("simple: adding self edge")
+	}
+
+	if _, ok := g.nodes[fid]; !ok {
+		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
+	}
+	if _, ok := g.nodes[tid]; !ok {
+		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
+	}
+
+	g.from[fid][tid] = e
+	g.to[tid][fid] = e
+}
+
+// To returns all nodes in g that can reach directly to n.
+func (g *dfdGraph) To(id int64) graph.Nodes {
+	if _, ok := g.from[id]; !ok {
+		return nil
+	}
+
+	to := make([]graph.Node, len(g.to[id]))
+	i := 0
+	for uid := range g.to[id] {
+		to[i] = g.nodes[uid]
+		i++
+	}
+	return iterator.NewOrderedNodes(to)
+}

--- a/dfd/dot_edge.go
+++ b/dfd/dot_edge.go
@@ -1,0 +1,51 @@
+package dfd
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+)
+
+// dotEdge extends simple.Edge with a label field to test round-trip encoding and
+// decoding of edge DOT label attributes.
+type dotEdge struct {
+	graph.Edge
+	Dir            string
+	Label          string
+	FromPortLabels dotPortLabels
+	ToPortLabels   dotPortLabels
+}
+
+// SetAttribute sets a DOT attribute.
+func (e *dotEdge) SetAttribute(attr encoding.Attribute) error {
+	switch attr.Key {
+	case "label":
+		e.Label = attr.Value
+	case "dir":
+		e.Dir = attr.Value
+	default:
+		return fmt.Errorf("unable to unmarshal edge DOT attribute with key %q", attr.Key)
+	}
+	return nil
+}
+
+func (e *dotEdge) SetFromPort(port, compass string) error {
+	e.FromPortLabels.Port = port
+	e.FromPortLabels.Compass = compass
+	return nil
+}
+
+func (e *dotEdge) SetToPort(port, compass string) error {
+	e.ToPortLabels.Port = port
+	e.ToPortLabels.Compass = compass
+	return nil
+}
+
+func (e *dotEdge) FromPort() (port, compass string) {
+	return e.FromPortLabels.Port, e.FromPortLabels.Compass
+}
+
+func (e *dotEdge) ToPort() (port, compass string) {
+	return e.ToPortLabels.Port, e.ToPortLabels.Compass
+}

--- a/dfd/dot_node.go
+++ b/dfd/dot_node.go
@@ -1,0 +1,68 @@
+package dfd
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+)
+
+// dotNode extends simple.Node with a label field to test round-trip encoding
+// and decoding of node DOT label attributes.
+type dotNode struct {
+	graph.Node
+	dotID string
+	// Node label.
+	Label string
+	Shape string
+	Style string
+	Dir   string
+}
+
+func (n *dotNode) ExternalID() string {
+	return n.dotID
+}
+
+// SetDOTID sets a DOT ID.
+func (n *dotNode) SetDOTID(id string) {
+	n.dotID = id
+}
+
+// SetAttribute sets a DOT attribute.
+func (n *dotNode) SetAttribute(attr encoding.Attribute) error {
+	switch attr.Key {
+	case "label":
+		n.Label = attr.Value
+	case "shape":
+		n.Shape = attr.Value
+	case "style":
+		n.Style = attr.Value
+	case "dir":
+		n.Dir = attr.Value
+	default:
+		return fmt.Errorf("unable to unmarshal node DOT attribute with key %q", attr.Key)
+	}
+
+	return nil
+}
+
+// Attributes returns the DOT attributes of the node.
+func (n *dotNode) Attributes() []encoding.Attribute {
+	if len(n.Label) == 0 && len(n.Shape) == 0 && len(n.Style) == 0 && len(n.Dir) == 0 {
+		return nil
+	}
+	var attrs []encoding.Attribute
+	if len(n.Label) != 0 {
+		attrs = append(attrs, encoding.Attribute{Key: "label", Value: n.Label})
+	}
+	if len(n.Shape) != 0 {
+		attrs = append(attrs, encoding.Attribute{Key: "shape", Value: n.Shape})
+	}
+	if len(n.Style) != 0 {
+		attrs = append(attrs, encoding.Attribute{Key: "style", Value: n.Style})
+	}
+	if len(n.Dir) != 0 {
+		attrs = append(attrs, encoding.Attribute{Key: "dir", Value: n.Dir})
+	}
+	return attrs
+}

--- a/dfd/graph.go
+++ b/dfd/graph.go
@@ -1,34 +1,43 @@
 package dfd
 
 import (
-	//"crypto/rand"
-	"fmt"
 	"strconv"
-	//"math"
-	//"math/big"
+	"sync"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-type structuredGraph struct {
-	*simple.DirectedGraph
+type dfdGraph struct {
 	id                string
 	graph, node, edge attributes
+	nodes             map[int64]graph.Node
+	from              map[int64]map[int64]graph.Edge
+	to                map[int64]map[int64]graph.Edge
+
+	nodeIDs Set
+
+	mtx sync.RWMutex
+}
+
+func NewDfdGraph() *dfdGraph {
+	return &dfdGraph{
+		id:    genID(),
+		nodes: make(map[int64]graph.Node),
+		from:  make(map[int64]map[int64]graph.Edge),
+		to:    make(map[int64]map[int64]graph.Edge),
+
+		nodeIDs: NewSet(),
+	}
 }
 
 // SetDOTID sets the DOT ID of the graph.
-func (g *structuredGraph) SetDOTID(id string) {
+func (g *dfdGraph) SetDOTID(id string) {
 	g.id = id
 }
 
-// DOTID returns the DOT ID of the graph.
-func (g *structuredGraph) DOTID() string {
-	return g.id
-}
-
-func (g *structuredGraph) NewNode() graph.Node {
+func (g *dfdGraph) NewNode() graph.Node {
 	//xid, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 	xid := genID()
 	xid64, _ := strconv.ParseInt(xid, 10, 64)
@@ -36,170 +45,11 @@ func (g *structuredGraph) NewNode() graph.Node {
 }
 
 // DOTAttributers implements the dot.Attributers interface.
-func (g *structuredGraph) DOTAttributers() (graph, node, edge encoding.Attributer) {
+func (g *dfdGraph) DOTAttributers() (graph, node, edge encoding.Attributer) {
 	return g.graph, g.node, g.edge
 }
 
 // DOTAttributeSetters implements the dot.AttributeSetters interface.
-func (g *structuredGraph) DOTAttributeSetters() (graph, node, edge encoding.AttributeSetter) {
+func (g *dfdGraph) DOTAttributeSetters() (graph, node, edge encoding.AttributeSetter) {
 	return &g.graph, &g.node, &g.edge
-}
-
-type subGraph struct {
-	*simple.DirectedGraph
-	id                string
-	graph, node, edge attributes
-}
-
-// SetDOTID sets the DOT ID of the graph.
-func (g *subGraph) SetDOTID(id string) {
-	g.id = id
-}
-
-func (g *subGraph) DOTID() string {
-	return fmt.Sprintf("cluster_%s", g.id)
-}
-
-// NewNode returns a new node with a unique node ID for the graph.
-func (g *subGraph) NewNode() graph.Node {
-	xid := genID()
-	xid64, _ := strconv.ParseInt(xid, 10, 64)
-	return &dotNode{Node: simple.Node(xid64)}
-}
-
-// NewEdge returns a new Edge from the source to the destination node.
-func (g *subGraph) NewEdge(from, to graph.Node) graph.Edge {
-	return &dotEdge{Edge: g.DirectedGraph.NewEdge(from, to)}
-}
-
-// DOTAttributers implements the dot.Attributers interface.
-func (g *subGraph) DOTAttributers() (graph, node, edge encoding.Attributer) {
-	return g.graph, g.node, g.edge
-}
-
-// DOTAttributeSetters implements the dot.AttributeSetters interface.
-func (g *subGraph) DOTAttributeSetters() (graph, node, edge encoding.AttributeSetter) {
-	return &g.graph, &g.node, &g.edge
-}
-
-// dotNode extends simple.Node with a label field to test round-trip encoding
-// and decoding of node DOT label attributes.
-type dotNode struct {
-	graph.Node
-	dotID string
-	// Node label.
-	Label string
-	Shape string
-	Style string
-	Dir   string
-}
-
-// DOTID returns the node's DOT ID.
-//func (n *dotNode) DOTID() string {
-//	return n.dotID
-//}
-
-func (n *dotNode) ExternalID() string {
-	return n.dotID
-}
-
-// SetDOTID sets a DOT ID.
-func (n *dotNode) SetDOTID(id string) {
-	n.dotID = id
-}
-
-// SetAttribute sets a DOT attribute.
-func (n *dotNode) SetAttribute(attr encoding.Attribute) error {
-	switch attr.Key {
-	case "label":
-		n.Label = attr.Value
-	case "shape":
-		n.Shape = attr.Value
-	case "style":
-		n.Style = attr.Value
-	case "dir":
-		n.Dir = attr.Value
-	default:
-		return fmt.Errorf("unable to unmarshal node DOT attribute with key %q", attr.Key)
-	}
-
-	return nil
-}
-
-// Attributes returns the DOT attributes of the node.
-func (n *dotNode) Attributes() []encoding.Attribute {
-	if len(n.Label) == 0 && len(n.Shape) == 0 && len(n.Style) == 0 && len(n.Dir) == 0 {
-		return nil
-	}
-	var attrs []encoding.Attribute
-	if len(n.Label) != 0 {
-		attrs = append(attrs, encoding.Attribute{Key: "label", Value: n.Label})
-	}
-	if len(n.Shape) != 0 {
-		attrs = append(attrs, encoding.Attribute{Key: "shape", Value: n.Shape})
-	}
-	if len(n.Style) != 0 {
-		attrs = append(attrs, encoding.Attribute{Key: "style", Value: n.Style})
-	}
-	if len(n.Dir) != 0 {
-		attrs = append(attrs, encoding.Attribute{Key: "dir", Value: n.Dir})
-	}
-	return attrs
-}
-
-// dotEdge extends simple.Edge with a label field to test round-trip encoding and
-// decoding of edge DOT label attributes.
-type dotEdge struct {
-	graph.Edge
-	Dir            string
-	Label          string
-	FromPortLabels dotPortLabels
-	ToPortLabels   dotPortLabels
-}
-
-// SetAttribute sets a DOT attribute.
-func (e *dotEdge) SetAttribute(attr encoding.Attribute) error {
-	switch attr.Key {
-	case "label":
-		e.Label = attr.Value
-	case "dir":
-		e.Dir = attr.Value
-	default:
-		return fmt.Errorf("unable to unmarshal edge DOT attribute with key %q", attr.Key)
-	}
-	return nil
-}
-
-func (e *dotEdge) SetFromPort(port, compass string) error {
-	e.FromPortLabels.Port = port
-	e.FromPortLabels.Compass = compass
-	return nil
-}
-
-func (e *dotEdge) SetToPort(port, compass string) error {
-	e.ToPortLabels.Port = port
-	e.ToPortLabels.Compass = compass
-	return nil
-}
-
-func (e *dotEdge) FromPort() (port, compass string) {
-	return e.FromPortLabels.Port, e.FromPortLabels.Compass
-}
-
-func (e *dotEdge) ToPort() (port, compass string) {
-	return e.ToPortLabels.Port, e.ToPortLabels.Compass
-}
-
-type attributes []encoding.Attribute
-
-func (a attributes) Attributes() []encoding.Attribute {
-	return []encoding.Attribute(a)
-}
-func (a *attributes) SetAttribute(attr encoding.Attribute) error {
-	*a = append(*a, attr)
-	return nil
-}
-
-type dotPortLabels struct {
-	Port, Compass string
 }

--- a/dfd/uid.go
+++ b/dfd/uid.go
@@ -1,0 +1,52 @@
+// Copyright ©2014 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package uid implements unique ID provision for graphs.
+package dfd
+
+// Max is the maximum value of int64.
+const Max = int64(^uint64(0) >> 1)
+
+// Set implements available ID storage.
+type Set struct {
+	maxID      int64
+	used, free Int64s
+}
+
+// NewSet returns a new Set. The returned value should not be passed except by pointer.
+func NewSet() Set {
+	return Set{maxID: -1, used: make(Int64s), free: make(Int64s)}
+}
+
+// NewID returns a new unique ID. The ID returned is not considered used
+// until passed in a call to use.
+func (s *Set) NewID() int64 {
+	for id := range s.free {
+		return id
+	}
+	if s.maxID != Max {
+		return s.maxID + 1
+	}
+	for id := int64(0); id <= s.maxID+1; id++ {
+		if !s.used.Has(id) {
+			return id
+		}
+	}
+	panic("unreachable")
+}
+
+// Use adds the id to the used IDs in the Set.
+func (s *Set) Use(id int64) {
+	s.used.Add(id)
+	s.free.Remove(id)
+	if id > s.maxID {
+		s.maxID = id
+	}
+}
+
+// Release frees the id for reuse.
+func (s *Set) Release(id int64) {
+	s.free.Add(id)
+	s.used.Remove(id)
+}


### PR DESCRIPTION
Originally this package relied on some existing simple graphs defined by
the gonum.org open source project. I ran into issues with race
conditions, so I've pulled in and refactored some of that existing code
to make it more concurrency friendly. There are likely still some gaps,
but as of now, `go test -race` and `go build -race` are not showing any
race conditions